### PR TITLE
fix: env var checks should be done in main.py

### DIFF
--- a/package_nso_to_oc/common.py
+++ b/package_nso_to_oc/common.py
@@ -9,13 +9,6 @@ from pathlib import Path, os as path_os
 from typing import Tuple
 
 
-if os.environ.get("NSO_URL", False) and os.environ.get("NSO_NED_FILE", False):
-    print("environment variable NSO_URL or NSO_NED_FILE must be set: not both")
-    exit()
-elif not os.environ.get("NSO_URL", False) and not os.environ.get("NSO_NED_FILE", False):
-    print("environment variable NSO_URL or NSO_NED_FILE must be set")
-    exit()
-
 # Different device OS
 XE = "xe"
 XR = "xr"


### PR DESCRIPTION
The checks for NSO_URL and NSO_NED_FILE are done both in main.py and common.py.  The checks in common.py should not be there because we do not want to check for these things if we are just consuming the package in python and want to pass in data programmatically (ie. when this package is not run from the command line).  This change does not break anything when running via main.py.