### PR TITLE
fix: Upgrade old pip version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -210,7 +210,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -287,7 +287,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -327,7 +327,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -412,7 +412,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -541,7 +541,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -614,7 +614,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -654,7 +654,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -735,7 +735,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -861,7 +861,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -934,7 +934,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip && source ~/.profile
+        run: sudo pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -974,7 +974,7 @@ jobs:
 #      - name: clone mdd
 #        run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
 #      - name: Upgrade pip
-#        run: pip install --upgrade pip && source ~/.profile
+#        run: sudo pip install --upgrade pip
 #      - name: Install PIP requirements
 #        run: pip install -r ./mdd_repo/requirements.txt
 #      - name: Install PIP virl2_client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -210,7 +210,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -287,7 +287,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -327,7 +327,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -412,7 +412,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -541,7 +541,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -614,7 +614,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -654,7 +654,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -735,7 +735,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -861,7 +861,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -934,7 +934,7 @@ jobs:
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip && source ~/.profile
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -974,7 +974,7 @@ jobs:
 #      - name: clone mdd
 #        run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
 #      - name: Upgrade pip
-#        run: pip install --upgrade pip
+#        run: pip install --upgrade pip && source ~/.profile
 #      - name: Install PIP requirements
 #        run: pip install -r ./mdd_repo/requirements.txt
 #      - name: Install PIP virl2_client

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -207,6 +209,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -282,6 +286,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -320,6 +326,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -403,6 +411,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -530,6 +540,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -601,6 +613,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -639,6 +653,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -718,6 +734,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -842,6 +860,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -913,6 +933,8 @@ jobs:
         run: sudo apt-get install git -y
       - name: clone mdd
         run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install PIP requirements
         run: pip install -r ./mdd_repo/requirements.txt
       - name: Install PIP virl2_client
@@ -951,6 +973,8 @@ jobs:
 #        run: sudo apt-get install git -y
 #      - name: clone mdd
 #        run: git clone https://github.com/model-driven-devops/mdd.git mdd_repo
+#      - name: Upgrade pip
+#        run: pip install --upgrade pip
 #      - name: Install PIP requirements
 #        run: pip install -r ./mdd_repo/requirements.txt
 #      - name: Install PIP virl2_client


### PR DESCRIPTION
Older versions of pip error out when installing the latest version of genie.  genie will eventually be fixed, but in the mean time, upgrade pip in the CI jobs before installing requirements.txt