### PR TITLE
fix: satisfy semantic-release-pypi assumption

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
 
       # actual configuration of semantic-release is done in .releaserc
       - name: Install dependencies
-        run: npm install semantic-release && npm install @semantic-release/exec conventional-changelog-conventionalcommits @semantic-release/release-notes-generator semantic-release-pypi
+        run: npm install semantic-release && npm install @semantic-release/exec @semantic-release/git conventional-changelog-conventionalcommits @semantic-release/release-notes-generator semantic-release-pypi
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -40,19 +40,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_TOKEN: ${{ secrets.CISCOPS_PYPI_TOKEN }}
         run: npx semantic-release
-
-      - name: Commit version change
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git commit -m "Update version" -a
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Push changes
-        run: |
-          git push origin HEAD:main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true

--- a/.releaserc
+++ b/.releaserc
@@ -5,21 +5,17 @@
       "preset": "conventionalcommits"
     }],
     "@semantic-release/release-notes-generator",
-    [
-        "@semantic-release/exec",
-        {
-            "prepareCmd": "sed -i 's|<package-version>.*</package-version>|<package-version>${nextRelease.version}</package-version>|g' mdd/package-meta-data.xml"
-        }
-    ],
-    [
-        "semantic-release-pypi",
-        {
-            "repoUrl": "https://upload.pypi.org/legacy/"
-        }
-    ],
     "@semantic-release/github",
     ["@semantic-release/exec", {
-        "publishCmd": "/bin/true"
+      "prepareCmd": "sed -i 's|<package-version>[0-9\\.]+</package-version>|<package-version>${nextRelease.version}</package-version>|' mdd/package-meta-data.xml"
+      "publishCmd": "/bin/true"
+    }],
+    ["@semantic-release/git", {
+      "assets": "mdd/package-meta-data.xml",
+      "message": "chore(release): Update NSO package version to ${nextRelease.version} [skip ci]"
+    }],
+    ["semantic-release-pypi", {
+      "repoUrl": "https://upload.pypi.org/legacy/"
     }]
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools","packaging"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "nso-oc"
+description = "Cisco NSO OpenConfig Tools"
+dynamic = ["version"]


### PR DESCRIPTION
Fix for MDD-677. The semantic-version-pypi plugin blindly assumes the presence of the “[project]” table in the pyproject.toml file